### PR TITLE
Use regex to avoid import side effects in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,13 +1,18 @@
 from setuptools import setup
+import re
 
-from numtraits import __version__
+def read(filename):
+    with open(filename) as f:
+        return f.read()
+
+__version__ = re.search(r'^__version__ = ([\'"])(?P<version>.*)\1$',
+                        read('numtraits.py'), re.M).groupdict()['version']
 
 try:
     import pypandoc
     long_description = pypandoc.convert('README.md', 'rst')
 except (IOError, ImportError):
-    with open('README.md') as infile:
-        long_description = infile.read()
+    long_description = read('README.md')
 
 setup(
     version=__version__,


### PR DESCRIPTION
First off, great work! This is something I'd love to see mature into a pan-kernel capability :) But let's get the pip/conda stuff bulletproof first!

Because `setup.py` imports the module itself, numtraits can't be installed unless numpy and traitlets are already available. Thus,

```
conda create -n numtraits python
pip install numtraits
```

would always fail, while 

```
conda create -n numtraits python
pip install numpy traitlets
pip install numtraits
```

would succeed... a decent workaround, but confusing unless you've encountered this kind of thing before.

This proposes using a regex to parse the module file, which would allow someone to do the first option, or include numtraits in a `requirements.txt` or `environment.yml`.
