### PR TITLE
Nullable traits and default value (WIP)

### DIFF
--- a/numtraits.py
+++ b/numtraits.py
@@ -25,7 +25,7 @@
 
 from __future__ import print_function
 
-from traitlets import TraitType, TraitError
+from traitlets import TraitType, TraitError, Undefined
 
 import numpy as np
 
@@ -38,23 +38,13 @@ QUANTITIES = 'quantities'
 class NumericalTrait(TraitType):
     info_text = 'a numerical trait, either a scalar or a vector'
     def __init__(self, ndim=None, shape=None, domain=None,
-                 default=None, convertible_to=None, nullable=False):
-        # We use the default value for the traitlet in the following cases:
-        # - default is not None,
-        # - default is None and the trait is nullable.
-        # In the other cases, we assume that a None default means that
-        # there is no default value defined.
-        if (default is None and nullable) or default is not None:
-            super(NumericalTrait, self).__init__(default_value=default)
-        else:
-            super(NumericalTrait, self).__init__()
+                 default_value=Undefined, convertible_to=None, allow_none=False):
+        super(NumericalTrait, self).__init__(default_value=default_value,allow_none=allow_none)
 
-        # Just store all the construction arguments.
+        # Store the construction arguments.
         self.ndim = ndim
         self.shape = shape
         self.domain = domain
-        self.default = default
-        self.nullable = nullable
         self.target_unit = convertible_to
 
         if self.target_unit is not None:
@@ -72,11 +62,6 @@ class NumericalTrait(TraitType):
                     raise TraitError("shape={0} and ndim={1} are inconsistent".format(self.shape, self.ndim))
 
     def validate(self, obj, value):
-        # If the trait is nullable and the value is None,
-        # then we have nothing to check.
-        if self.nullable and value is None:
-            return value
-
         # We proceed by checking whether Numpy tells us the value is a
         # scalar. If Numpy isscalar returns False, it could still be scalar
         # but be a Quantity with units, so we then extract the numerical

--- a/test_numtraits.py
+++ b/test_numtraits.py
@@ -94,7 +94,7 @@ class TestScalar(object):
         assert self.sp.i == 1.23
         with pytest.raises(TraitError) as exc:
             self.sp.i = None
-        assert exc.value.args[0] == "radius should be a scalar value"
+        assert exc.value.args[0] == "i should be a scalar value"
 
 
 class ArrayProperties(HasTraits):

--- a/test_numtraits.py
+++ b/test_numtraits.py
@@ -15,6 +15,7 @@ class ScalarProperties(HasTraits):
     f = NumericalTrait(ndim=0, domain=(3, 4))
     g = NumericalTrait(ndim=0, nullable=True)
     h = NumericalTrait(ndim=0, nullable=True, default=1.23)
+    i = NumericalTrait(ndim=0, default=4.56)
 
 class TestScalar(object):
 
@@ -81,13 +82,20 @@ class TestScalar(object):
             self.sp.f = 7
         assert exc.value.args[0] == "f should be in the range [3:4]"
 
-    def test_nullable(self):
+    def test_nullable_default(self):
         assert self.sp.g is None
-        assert self.sp.h is not None
+        assert self.sp.h == 1.23
+        assert self.sp.i == 4.56
         self.sp.g = 1.2
         assert self.sp.g == 1.2
         self.sp.h = None
         assert self.sp.h is None
+        self.sp.i = 1.23
+        assert self.sp.i == 1.23
+        with pytest.raises(TraitError) as exc:
+            self.sp.i = None
+        assert exc.value.args[0] == "radius should be a scalar value"
+
 
 class ArrayProperties(HasTraits):
 

--- a/test_numtraits.py
+++ b/test_numtraits.py
@@ -13,9 +13,9 @@ class ScalarProperties(HasTraits):
     d = NumericalTrait(ndim=0, domain='negative')
     e = NumericalTrait(ndim=0, domain='strictly-negative')
     f = NumericalTrait(ndim=0, domain=(3, 4))
-    g = NumericalTrait(ndim=0, nullable=True)
-    h = NumericalTrait(ndim=0, nullable=True, default=1.23)
-    i = NumericalTrait(ndim=0, default=4.56)
+    g = NumericalTrait(ndim=0, allow_none=True, default_value=None)
+    h = NumericalTrait(ndim=0, allow_none=True, default_value=1.23)
+    i = NumericalTrait(ndim=0, default_value=4.56)
 
 class TestScalar(object):
 

--- a/test_numtraits.py
+++ b/test_numtraits.py
@@ -13,6 +13,8 @@ class ScalarProperties(HasTraits):
     d = NumericalTrait(ndim=0, domain='negative')
     e = NumericalTrait(ndim=0, domain='strictly-negative')
     f = NumericalTrait(ndim=0, domain=(3, 4))
+    g = NumericalTrait(ndim=0, nullable=True)
+    h = NumericalTrait(ndim=0, nullable=True, default=1.23)
 
 class TestScalar(object):
 
@@ -79,6 +81,13 @@ class TestScalar(object):
             self.sp.f = 7
         assert exc.value.args[0] == "f should be in the range [3:4]"
 
+    def test_nullable(self):
+        assert self.sp.g is None
+        assert self.sp.h is not None
+        self.sp.g = 1.2
+        assert self.sp.g == 1.2
+        self.sp.h = None
+        assert self.sp.h is None
 
 class ArrayProperties(HasTraits):
 


### PR DESCRIPTION
A small extension that enables numtraits to be nullable (i.e., `None` can be assigned to a trait) and to be constructed with a default value.
